### PR TITLE
Motion Timestamp and Sensitivity Scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ You can use swipes for the keyboard, the button codes are described below.
 ## Gyroscope
 1. Check Windows Firewall to see if incoming connections are allowed on your network type (private) and allow if disabled.
 2. Install FreePieIMU on your Android phone by taking the latest version in the [OpenTrack archive](https://github.com/opentrack/opentrack) or in the [releases](https://github.com/r57zone/DualShock4-emulator/releases), enter the IP address of your computer, select "Send raw data", if not selected, select the data rate "Fastest" or "Fast".
-3. Reduce the sensitivity if necessary (the `Sens` parameter, in the `Motion` section, where `100` is 100% sensitivity) in configuration file.
-4. Invert the axes if necessary (the parameters `InverseX`, `InverseY` and `InverseZ`, in the `Motion` section, where `1` is turning on the inversion, and `0` is turning off).
-5. Change phone orientation (the parameter `Orientation`, in the `Motion` section. where `1` is landscape and `0` is portrait).
+3. Reduce the general sensitivity if necessary (the `Sens` parameter, in the `Motion` section, where `100` is 100% sensitivity) in configuration file.
+4. Reduce individual sensor sensitivity if necessary (the `AccelSens` and `GyroSense`, in the `Motion` section,  where `100` is 100% sensitivity) in configuration file.
+5. Invert the axes if necessary (the parameters `InverseX`, `InverseY` and `InverseZ`, in the `Motion` section, where `1` is turning on the inversion, and `0` is turning off).
+6. Change phone orientation (the parameter `Orientation`, in the `Motion` section. where `1` is landscape and `0` is portrait).
 
 If you just need to shake (gyro) the gamepad in the game, then there is no need to install Android applications, just press the "shake" button of the gamepad.
 


### PR DESCRIPTION
Possible fix #32.

Works well with motion aiming in "Days Gone".

Recommended default motion config:

[Motion]
Activate=1
Port=5555
Sens=50
AccelSens=50
GyroSens=50
InverseX=1
InverseY=0
InverseZ=1
SleepTimeOut=1
Orientation=1