### PR TITLE
Add configurable default profile and default mouse centering option

### DIFF
--- a/Source/DS4Emulator.cpp
+++ b/Source/DS4Emulator.cpp
@@ -266,6 +266,8 @@ int main(int argc, char **argv)
 	if (CursorHidden) { SetSystemCursor(CursorEmpty, OCR_NORMAL); CursorHidden = true; }
 
 	// Config parameters
+	std::string defaultProfile = IniFile.ReadString("Main", "DefaultProfile", "Default");
+
 	KEY_ID_STOP_CENTERING_NAME = IniFile.ReadString("KeyboardMouse", "StopCenteringKey", "C");
 	int KEY_ID_STOP_CENTERING = KeyNameToKeyCode(KEY_ID_STOP_CENTERING_NAME);
 	bool CenteringEnable = true;
@@ -317,10 +319,10 @@ int main(int argc, char **argv)
 	WIN32_FIND_DATA ffd;
 	HANDLE hFind = INVALID_HANDLE_VALUE;
 	hFind = FindFirstFile("Profiles\\*.ini", &ffd);
-	KMProfiles.push_back("Default.ini");
+	KMProfiles.push_back(defaultProfile + ".ini");
 	if (hFind != INVALID_HANDLE_VALUE) {
 		do {
-			if (strcmp(ffd.cFileName, "Default.ini")) // Already added to the top of the list
+			if (strcmp(ffd.cFileName, (defaultProfile + ".ini").c_str())) // Already added to the top of the list
 				KMProfiles.push_back(ffd.cFileName);
 		} while (FindNextFile(hFind, &ffd) != 0);
 		FindClose(hFind);

--- a/Source/DS4Emulator.cpp
+++ b/Source/DS4Emulator.cpp
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
 
 	KEY_ID_STOP_CENTERING_NAME = IniFile.ReadString("KeyboardMouse", "StopCenteringKey", "C");
 	int KEY_ID_STOP_CENTERING = KeyNameToKeyCode(KEY_ID_STOP_CENTERING_NAME);
-	bool CenteringEnable = true;
+	bool CenteringEnable = IniFile.ReadBoolean("KeyboardMouse", "EnableCentering", true);
 
 	bool InvertX = IniFile.ReadBoolean("Main", "InvertX", false);
 	bool InvertY = IniFile.ReadBoolean("Main", "InvertY", false);


### PR DESCRIPTION
Instead of switching through profiles or overwriting the default supplied profile, choose a custom default feels slightly cleaner.

Allowing a default-off for mouse centering for RStick emulation increases ease of use when playing games with the default RPCS3 DS4 config + KAMI.
